### PR TITLE
Fix critical TypeScript errors in federation.ts and make TypeScript federated example run at a bare minimum.

### DIFF
--- a/src/example/generated/DistributedLogical/Distributed_dsp.ts
+++ b/src/example/generated/DistributedLogical/Distributed_dsp.ts
@@ -100,7 +100,7 @@ export class Distributed extends FederatedApp {
         success?: () => void, 
         fail?: () => void
     ) {
-        super(1, 15044, "localhost", timeout, keepAlive, fast, success, fail);
+        super(1, 15045, "localhost", timeout, keepAlive, fast, success, fail);
         this.dsp = new PrintMessage(this)
         this.networkMessage = new Action<Buffer>(this, Origin.logical, TimeValue.withUnits(10, TimeUnit.msec));
         this.registerFederatePortAction(0, this.networkMessage);

--- a/src/example/generated/DistributedLogical/Distributed_msg.ts
+++ b/src/example/generated/DistributedLogical/Distributed_msg.ts
@@ -100,7 +100,7 @@ export class Distributed extends FederatedApp {
         success?: () => void, 
         fail?: () => void
     ) {
-        super(0, 15044, "localhost", timeout, keepAlive, fast, success, fail);
+        super(0, 15045, "localhost", timeout, keepAlive, fast, success, fail);
         this.msg = new MessageGenerator(this, "Hello World")
         this.networkMessage = new Action<string>(this, Origin.logical, TimeValue.withUnits(10, TimeUnit.msec));
         this.addReaction(

--- a/src/example/generated/README.md
+++ b/src/example/generated/README.md
@@ -3,8 +3,11 @@ The contents of this directory illustrate how to create a federated reactor in r
 The two directories DistributedPhysical and DistributedLogical each have an example sender and receiver program for a logical and a physical connection. These examples are meant to immitate the C target example for the RTI at lingua-franca/example/Distributed. To run the example programs
 
 1) Build the reactor-ts repo via $npm run build.
-2) Compile the C RTI example program at lingua-franca/example/Distributed.
-3) Start the generated C RTI program at lingua-franca/example/Distributed/bin/Distributed_RTI
+2) Compile the C RTI example program at lingua-franca/example/C/src/DistributedHelloWorld/.
+3) Start the generated C RTI program at lingua-franca/example/C/bin/HelloWorld_RTI
+4) Change directory to /lingua-franca/org.lflang/src/lib/TS/reactor-ts
+5) Run generated Distributed_msg with `node dist/example/generated/DistributedLogical/Distributed_msg.js`
+5) Run generated Distributed_dsp with `node dist/example/generated/DistributedLogical/Distributed_dsp.js`
 
 Note that Distributed_RTI is generated with information about this specific Federate topology, and won't work with any other model than a Sender and a Destination with the correct PortIDs and FederateIDs.
 


### PR DESCRIPTION
This fix allows the dormant TypeScript federated example to run at a bare minimum.

The example federates can now connect to the C-compiled RTI (HelloWorld_RTI) and advance time correctly. Also, now, the source reactor (in Distributed_msg.ts) can generate messages correctly, and the destination reactor (in Distributed_dsp.ts) can display messages.

Major errors fixed are:
* Message format of MSG_TYPE_FED_IDS.
* Formats of messages with missing microsteps.
* Missing MSG_TYPE_UDP_PORT message.