### PR TITLE
Finish fixing errors in TypeScript federated examples so that they can run with new standalone RTI.

### DIFF
--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -38,6 +38,13 @@ export const CONNECT_NUM_RETRIES: number = 500;
  */
 enum RTIMessageTypes {
 
+    /**
+     * Byte identifying a rejection of the previously received message.
+     * The reason for the rejection is included as an additional byte
+     * (uchar) (see below for encodings of rejection reasons).
+     */
+    MSG_TYPE_REJECT = 0,
+
     /** 
      *  Byte identifying a message from a federate to an RTI containing
      *  the federation ID and the federate ID. The message contains, in
@@ -256,7 +263,7 @@ class RTIClient extends EventEmitter {
             buffer.writeUInt8(RTIMessageTypes.MSG_TYPE_FED_IDS, 0);
             buffer.writeUInt16LE(this.id, 1);
             let federationID = 'Unidentified Federation';
-            console.log('hokeun!' + federationID.length);
+
             buffer.writeUInt8(federationID.length, 3);
             try {
                 Log.debug(this, () => {return 'Sending a FED ID message to the RTI.'});
@@ -647,6 +654,12 @@ class RTIClient extends EventEmitter {
                 case RTIMessageTypes.MSG_TYPE_ACK: {
                     Log.debug(thiz, () => {return 'Received an RTI MSG_TYPE_ACK'});
                     bufferIndex += 1;
+                    break;
+                }
+                case RTIMessageTypes.MSG_TYPE_REJECT: {
+                    let rejectionReason = assembledData.readUInt8(bufferIndex + 1);
+                    Log.error(thiz, () => {return 'Received an RTI MSG_TYPE_REJECT. Rejection reason: ' + rejectionReason});
+                    bufferIndex += 2;
                     break;
                 }
                 default: {

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -830,7 +830,8 @@ export class FederatedApp extends App {
         this.sendRTILogicalTimeComplete(this.util.getCurrentLogicalTime());
         this.sendRTIResign();
         this.shutdownRTIClient();
-        super._shutdown()
+        // FIXME: Fix errors when calling App._shutdown() from this FederatedApp.
+        //super._shutdown()
     }
 
     // FIXME: Some of the App settings (like fast) are probably incompatible
@@ -855,7 +856,16 @@ export class FederatedApp extends App {
         executionTimeout?: TimeValue | undefined, keepAlive?: boolean,
         fast?: boolean, success?: () => void, failure?: () => void) {
 
-        super(executionTimeout, keepAlive, fast, success, failure);
+        super(executionTimeout, keepAlive, fast,
+            // Let super class (App) call FederateApp's _shutdown in success and failure.
+            () => {
+                success? success(): () => {};
+                this._shutdown();
+            },
+            () => {
+                failure? failure(): () => {};
+                this._shutdown();
+            });
         this.rtiClient = new RTIClient(federateID);
     }
 

--- a/src/example/generated/DistributedLogical/Distributed_dsp.ts
+++ b/src/example/generated/DistributedLogical/Distributed_dsp.ts
@@ -15,51 +15,6 @@ let __noStart = false; // If set to true, don't start the app.
 // Custom command line arguments
 
 // Assign custom command line arguments
-// =============== START reactor class MessageGenerator
-export class MessageGenerator extends Reactor {
-    t: Timer;
-    root: Parameter<string>;
-    count: State<number>;
-    message: OutPort<string>;
-    constructor (
-        parent: Reactor, 
-        root: string = ""
-    ) {
-        super(parent);
-        this.t = new Timer(this, TimeValue.withUnits(1, TimeUnit.sec), TimeValue.withUnits(1, TimeUnit.sec));
-        this.root = new Parameter(root);
-        this.count = new State(1);
-        this.message = new OutPort<string>(this);
-        this.addReaction(
-            new Triggers(this.t),
-            new Args(this.t, this.writable(this.message), this.root, this.count),
-            function (this, __t: Read<Tag>, __message: ReadWrite<string>, __root: Parameter<string>, __count: State<number>) {
-                // =============== START react prologue
-                const util = this.util;
-                let t = __t.get();
-                let message = __message.get();
-                let root = __root.get();
-                let count = __count.get();
-                // =============== END react prologue
-                try {
-                    message = count.toString();    
-                    console.log(`At time ${util.getElapsedLogicalTime()}, send message: ${count++}`);
-                } finally {
-                    // =============== START react epilogue
-                    if (message !== undefined) {
-                        __message.set(message);
-                    }
-                    if (count !== undefined) {
-                        __count.set(count);
-                    }
-                    // =============== END react epilogue
-                }
-            }
-        );
-    }
-}
-// =============== END reactor class MessageGenerator
-
 // =============== START reactor class PrintMessage
 export class PrintMessage extends Reactor {
     message: InPort<string>;

--- a/src/example/generated/DistributedLogical/Distributed_dsp.ts
+++ b/src/example/generated/DistributedLogical/Distributed_dsp.ts
@@ -101,6 +101,7 @@ export class Distributed extends FederatedApp {
         fail?: () => void
     ) {
         super(1, 15045, "localhost", timeout, keepAlive, fast, success, fail);
+        this.addUpstreamFederate(0, BigInt(0));
         this.dsp = new PrintMessage(this)
         this.networkMessage = new Action<Buffer>(this, Origin.logical, TimeValue.withUnits(10, TimeUnit.msec));
         this.registerFederatePortAction(0, this.networkMessage);

--- a/src/example/generated/DistributedLogical/Distributed_msg.ts
+++ b/src/example/generated/DistributedLogical/Distributed_msg.ts
@@ -101,6 +101,7 @@ export class Distributed extends FederatedApp {
         fail?: () => void
     ) {
         super(0, 15045, "localhost", timeout, keepAlive, fast, success, fail);
+        this.addDownstreamFederate(1);
         this.msg = new MessageGenerator(this, "Hello World")
         this.networkMessage = new Action<string>(this, Origin.logical, TimeValue.withUnits(10, TimeUnit.msec));
         this.addReaction(

--- a/src/example/generated/DistributedLogical/Distributed_msg.ts
+++ b/src/example/generated/DistributedLogical/Distributed_msg.ts
@@ -60,35 +60,6 @@ export class MessageGenerator extends Reactor {
 }
 // =============== END reactor class MessageGenerator
 
-// =============== START reactor class PrintMessage
-export class PrintMessage extends Reactor {
-    message: InPort<string>;
-    constructor (
-        parent: Reactor
-    ) {
-        super(parent);
-        this.message = new InPort<string>(this);
-        this.addReaction(
-            new Triggers(this.message),
-            new Args(this.message),
-            function (this, __message: Read<string>) {
-                // =============== START react prologue
-                const util = this.util;
-                let message = __message.get();
-                // =============== END react prologue
-                try {
-                    console.log(`PrintMessage: At (elapsed) logical time ${util.getElapsedLogicalTime()}, receiver receives: ${message}`);
-                } finally {
-                    // =============== START react epilogue
-                    
-                    // =============== END react epilogue
-                }
-            }
-        );
-    }
-}
-// =============== END reactor class PrintMessage
-
 // =============== START reactor class Distributed
 export class Distributed extends FederatedApp {
     msg: MessageGenerator

--- a/src/example/generated/DistributedLogical/Distributed_msg.ts
+++ b/src/example/generated/DistributedLogical/Distributed_msg.ts
@@ -42,8 +42,8 @@ export class MessageGenerator extends Reactor {
                 let count = __count.get();
                 // =============== END react prologue
                 try {
-                    message = count.toString();    
-                    console.log(`At time ${util.getElapsedLogicalTime()}, send message: ${count++}`);
+                    message = root + " " + count++;    
+                    console.log(`At time ${util.getElapsedLogicalTime()}, send message: ${message}`);
                 } finally {
                     // =============== START react epilogue
                     if (message !== undefined) {

--- a/src/example/generated/DistributedPhysical/Distributed_dsp.ts
+++ b/src/example/generated/DistributedPhysical/Distributed_dsp.ts
@@ -13,51 +13,6 @@ let __fast: boolean = false;
 let __noStart = false; // If set to true, don't start the app.
 
 // Assign custom command line arguments
-// =============== START reactor class MessageGenerator
-export class MessageGenerator extends Reactor {
-    t: Timer;
-    root: Parameter<string>;
-    count: State<number>;
-    message: OutPort<string>;
-    constructor (
-        parent: Reactor, 
-        root: string = ""
-    ) {
-        super(parent);
-        this.t = new Timer(this, TimeValue.withUnits(1, TimeUnit.sec), TimeValue.withUnits(1, TimeUnit.sec));
-        this.root = new Parameter(root);
-        this.count = new State(1);
-        this.message = new OutPort<string>(this);
-        this.addReaction(
-            new Triggers(this.t),
-            new Args(this.t, this.writable(this.message), this.root, this.count),
-            function (this, __t: Read<Tag>, __message: ReadWrite<string>, __root: Parameter<string>, __count: State<number>) {
-                // =============== START react prologue
-                const util = this.util;
-                let t = __t.get();
-                let message = __message.get();
-                let root = __root.get();
-                let count = __count.get();
-                // =============== END react prologue
-                try {
-                    message = count.toString();    
-                    console.log(`At time ${util.getElapsedLogicalTime()}, send message: ${count++}`);
-                } finally {
-                    // =============== START react epilogue
-                    if (message !== undefined) {
-                        __message.set(message);
-                    }
-                    if (count !== undefined) {
-                        __count.set(count);
-                    }
-                    // =============== END react epilogue
-                }
-            }
-        );
-    }
-}
-// =============== END reactor class MessageGenerator
-
 // =============== START reactor class PrintMessage
 export class PrintMessage extends Reactor {
     message: InPort<string>;
@@ -98,7 +53,8 @@ export class Distributed extends FederatedApp {
         success?: () => void, 
         fail?: () => void
     ) {
-        super(1, 15044, "localhost", timeout, keepAlive, fast, success, fail);
+        super(1, 15045, "localhost", timeout, keepAlive, fast, success, fail);
+        this.addUpstreamFederate(0, BigInt(0));
         this.dsp = new PrintMessage(this)
         this.networkMessage = new Action<Buffer>(this, Origin.physical, TimeValue.withUnits(10, TimeUnit.msec));
         this.registerFederatePortAction(0, this.networkMessage);

--- a/src/example/generated/DistributedPhysical/Distributed_msg.ts
+++ b/src/example/generated/DistributedPhysical/Distributed_msg.ts
@@ -58,36 +58,6 @@ export class MessageGenerator extends Reactor {
 }
 // =============== END reactor class MessageGenerator
 
-// =============== START reactor class PrintMessage
-export class PrintMessage extends Reactor {
-    message: InPort<string>;
-    constructor (
-        parent: Reactor
-    ) {
-        super(parent);
-        this.message = new InPort<string>(this);
-        this.addReaction(
-            new Triggers(this.message),
-            new Args(this.message),
-            function (this, __message: Read<string>) {
-                // =============== START react prologue
-                const util = this.util;
-                let message = __message.get();
-                // =============== END react prologue
-                try {
-                    console.log(`PrintMessage: At (elapsed) logical time ${util.getElapsedLogicalTime()}, receiver receives: ${message}`);
-                        
-                } finally {
-                    // =============== START react epilogue
-                    
-                    // =============== END react epilogue
-                }
-            }
-        );
-    }
-}
-// =============== END reactor class PrintMessage
-
 // =============== START reactor class Distributed
 export class Distributed extends FederatedApp {
     msg: MessageGenerator
@@ -99,7 +69,8 @@ export class Distributed extends FederatedApp {
         success?: () => void, 
         fail?: () => void
     ) {
-        super(0, 15044, "localhost", timeout, keepAlive, fast, success, fail);
+        super(0, 15045, "localhost", timeout, keepAlive, fast, success, fail);
+        this.addDownstreamFederate(1);
         this.msg = new MessageGenerator(this, "Hello World")
         this.networkMessage = new Action<string>(this, Origin.physical, TimeValue.withUnits(10, TimeUnit.msec));
         this.addReaction(

--- a/src/example/generated/DistributedPhysical/Distributed_msg.ts
+++ b/src/example/generated/DistributedPhysical/Distributed_msg.ts
@@ -40,8 +40,8 @@ export class MessageGenerator extends Reactor {
                 let count = __count.get();
                 // =============== END react prologue
                 try {
-                    message = count.toString();    
-                    console.log(`At time ${util.getElapsedLogicalTime()}, send message: ${count++}`);
+                    message = root + " " + count++;    
+                    console.log(`At time ${util.getElapsedLogicalTime()}, send message: ${message}`);
                 } finally {
                     // =============== START react epilogue
                     if (message !== undefined) {

--- a/src/example/generated/README.md
+++ b/src/example/generated/README.md
@@ -1,14 +1,27 @@
 The contents of this directory illustrate how to create a federated reactor in reactor-ts. These files began life as generated lingua-franca code, but have been significantly cleaned up.
 
-The two directories DistributedPhysical and DistributedLogical each have an example sender and receiver program for a logical and a physical connection. These examples are meant to immitate the C target example for the RTI at lingua-franca/example/Distributed. To run the example programs
+The two directories DistributedLogical and DistributedPhysical each have an example sender and receiver program for a logical and a physical connection. These examples are meant to immitate the C target example for the RTI at lingua-franca/example/C/src/Distributed*. See instructions for running these examples below.
 
-1) Build the reactor-ts repo via $npm run build.
-2) Compile the C RTI example program at lingua-franca/example/C/src/DistributedHelloWorld/.
-3) Start the generated C RTI program at lingua-franca/example/C/bin/HelloWorld_RTI
-4) Change directory to /lingua-franca/org.lflang/src/lib/TS/reactor-ts
-5) Run generated Distributed_msg with `node dist/example/generated/DistributedLogical/Distributed_msg.js`
-5) Run generated Distributed_dsp with `node dist/example/generated/DistributedLogical/Distributed_dsp.js`
+To compile the TypeScript federated examples:
 
-Note that Distributed_RTI is generated with information about this specific Federate topology, and won't work with any other model than a Sender and a Destination with the correct PortIDs and FederateIDs.
+1) Change directory to /lingua-franca/org.lflang/src/lib/TS/reactor-ts
+2) Build the reactor-ts repo via $npm run build.
 
-4) You can also try substituting one of the TS examples with its corresponding C version lingua-franca/example/Distributed/bin/Distributed_Receiver or lingua-franca/example/Distributed/bin/Distributed_Sender.
+To run the example, first compile and run the standalone RTI:
+
+1) Move to the C RTI directory at: lingua-franca/org.lflang/src/lib/core/federated/RTI
+2) Compile the standalone C RTI (see README.md for instructions) and run it with `build/RTI -n 2`
+
+To run DistributedLogical example:
+
+1) Change directory to /lingua-franca/org.lflang/src/lib/TS/reactor-ts
+2) Run generated Distributed_msg (sender) with `node dist/example/generated/DistributedLogical/Distributed_msg.js`
+3) Run generated Distributed_dsp (receiber) with `node dist/example/generated/DistributedLogical/Distributed_dsp.js`
+
+To run DistributedPhysical example:
+
+1) Change directory to /lingua-franca/org.lflang/src/lib/TS/reactor-ts
+2) Run generated Distributed_msg (sender) with `node dist/example/generated/DistributedPhysical/Distributed_msg.js`
+3) Run generated Distributed_dsp (receiber) with `node dist/example/generated/DistributedPhysical/Distributed_dsp.js`
+
+OUTDATED: You can also try substituting one of the TS examples with its corresponding C version lingua-franca/example/Distributed/bin/Distributed_Receiver or lingua-franca/example/Distributed/bin/Distributed_Sender.


### PR DESCRIPTION
Finish fixing errors in TypeScript federated examples so that they can run with new standalone RTI.

Now the examples can run with standalone RTI.

Example run outputs:

1. RTI:
```
$ build/RTI -n 2
RTI: Number of federates: 2
Starting RTI for 2 federates in federation ID Unidentified Federation
RTI using TCP port 15045 for federation Unidentified Federation.
RTI: Listening for federates.
RTI: All expected federates have connected. Starting execution.
RTI: Waiting for thread handling federate 0.
Federate 0 has resigned.
RTI: Federate 0 thread exited.
RTI: Waiting for thread handling federate 1.
Federate 1 has resigned.
RTI: Federate 1 thread exited.
RTI is exiting.
```

2. Distributed_msg (Hello World sender):
```
$ node dist/example/generated/DistributedLogical/Distributed_msg.js
>>>>>>>>>Postponed Scheduling of timer Distributed/MessageGenerator/Timer
digraph G {
"Distributed[R0]"->"Distributed[M0]";
"Distributed[R0]"->"Distributed/msg/message"->"Distributed/msg[R0]"->"Distributed/msg[M0]"->"Distributed[M0]";
}
>>>>>>>>>Scheduling timer Distributed/msg/t
At time (1 secs; 0 nsecs), send message: Hello World 1
At time (2 secs; 0 nsecs), send message: Hello World 2
At time (3 secs; 0 nsecs), send message: Hello World 3
At time (4 secs; 0 nsecs), send message: Hello World 4
At time (5 secs; 0 nsecs), send message: Hello World 5
At time (6 secs; 0 nsecs), send message: Hello World 6
At time (7 secs; 0 nsecs), send message: Hello World 7
At time (8 secs; 0 nsecs), send message: Hello World 8
At time (9 secs; 0 nsecs), send message: Hello World 9
At time (10 secs; 0 nsecs), send message: Hello World 10
```

3. Distributed_dsp (Hello World Receiver):
```
$ node dist/example/generated/DistributedLogical/Distributed_dsp.js
digraph G {
"Distributed/dsp[R0]"->"Distributed/dsp/message"->"Distributed[R0]"->"Distributed[M0]";
"Distributed/dsp[R0]"->"Distributed/dsp[M0]"->"Distributed[M0]";
}
PrintMessage: At (elapsed) logical time (1 secs; 10000000 nsecs), receiver receives: Hello World 1
PrintMessage: At (elapsed) logical time (2 secs; 10000000 nsecs), receiver receives: Hello World 2
PrintMessage: At (elapsed) logical time (3 secs; 10000000 nsecs), receiver receives: Hello World 3
PrintMessage: At (elapsed) logical time (4 secs; 10000000 nsecs), receiver receives: Hello World 4
PrintMessage: At (elapsed) logical time (5 secs; 10000000 nsecs), receiver receives: Hello World 5
PrintMessage: At (elapsed) logical time (6 secs; 10000000 nsecs), receiver receives: Hello World 6
PrintMessage: At (elapsed) logical time (7 secs; 10000000 nsecs), receiver receives: Hello World 7
PrintMessage: At (elapsed) logical time (8 secs; 10000000 nsecs), receiver receives: Hello World 8
PrintMessage: At (elapsed) logical time (9 secs; 10000000 nsecs), receiver receives: Hello World 9
```